### PR TITLE
ACSP-228 - run scripts as post app deploy hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ Here are the events with the minimal required fields you need to subscribe to, i
 | Order          | observer.sales_order_save_commit_after                 | created_at, updated_at      | order update ([hold](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/ordersidhold#operation/PostV1OrdersIdHold), [unhold](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/ordersidunhold#operation/PostV1OrdersIdUnhold), [cancel](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/ordersidcancel#operation/PostV1OrdersIdCancel), [emails](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/ordersidemails#operation/PostV1OrdersIdEmails)) |
 | Stock          | observer.cataloginventory_stock_item_save_commit_after | product_id                  | product [stock update](https://adobe-commerce.redoc.ly/2.4.6-admin/tag/productsproductSkustockItemsitemId/#operation/PutV1ProductsProductSkuStockItemsItemId)                                                                                                                                                                                                                                                                               |
 
+### Automating the execution of onboarding and event subscription
+App builder defines lifecycle event hooks that make possible to automatically execute custom code when a particular application lifecycle event happens.
+To learn more these hooks navigate to [App Builder application tooling lifecycle event hooks](https://developer.adobe.com/app-builder/docs/guides/app-hooks/).
+
+This code snapshot in the `app.config.yaml` file shows how to define a hook that will execute the onboarding and event subscription scripts after the application has been deployed:
+
+```yaml
+application:
+  hooks:
+    post-app-deploy: ./hooks/post-app-deploy.js
+```
+
+For convenience, the hook configuration is commented out in the `app.config.yaml` file. To enable the hook, uncomment the hook configuration.
+
 ## Development
 
 * [Project source code structure](#project-source-code-structure)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Here are the events with the minimal required fields you need to subscribe to, i
 App builder defines lifecycle event hooks that make possible to automatically execute custom code when a particular application lifecycle event happens.
 To learn more these hooks navigate to [App Builder application tooling lifecycle event hooks](https://developer.adobe.com/app-builder/docs/guides/app-hooks/).
 
-This code snapshot in the `app.config.yaml` file shows how to define a hook that will execute the onboarding and event subscription scripts after the application has been deployed:
+The following code snapshot in the `app.config.yaml` file shows how to define a hook that will execute the onboarding and event subscription scripts after the application has been deployed:
 
 ```yaml
 application:
@@ -220,6 +220,8 @@ application:
 ```
 
 For convenience, the hook configuration is commented out in the `app.config.yaml` file. To enable the hook, uncomment the hook configuration.
+
+If you plan to add more hooks to the application, you can define them in the `hooks` folder and reference them in the `app.config.yaml` file.
 
 ## Development
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -1,6 +1,6 @@
 application:
-  hooks:
-    post-app-deploy: ./hooks/post-app-deploy.js
+#  hooks:
+#    post-app-deploy: ./hooks/post-app-deploy.js
   runtimeManifest:
     packages:
       starter-kit:

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -1,4 +1,6 @@
 application:
+  hooks:
+    post-app-deploy: ./hooks/post-app-deploy.js
   runtimeManifest:
     packages:
       starter-kit:

--- a/hooks/post-app-deploy.js
+++ b/hooks/post-app-deploy.js
@@ -1,3 +1,4 @@
 module.exports = () => {
     require('../scripts/onboarding/index.js').main()
+    require('../scripts/commerce-event-subscribe/index.js').main()
 }

--- a/hooks/post-app-deploy.js
+++ b/hooks/post-app-deploy.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+    require('../scripts/onboarding/index.js').main()
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Configure the `onboarding` and `commerce-event-subscribe` scripts as post-app deploy hooks, following the instructions at https://developer.adobe.com/app-builder/docs/guides/app-hooks/.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Automate the scripts so they are triggered after each application deployment and the developer does not event has to think about it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It's been testing connecting the code to an App Builder project, deploying it, and
* confirming that the scripts are triggered after the application deployment
* verifying that the execution of the scripts produced the expected outcome

## Screenshots (if appropriate):

This is the output shown in the terminal when running `aio app deploy`.
It can be verified that once the deployment is done, the `onboarding` and `commerce-event-subscribe` processes are automatically triggered.

**Note**: when deploying an individual action the `post-app-deploy` hook is also triggered

```
aio app deploy
✔ Built 34 action(s) for 'application'
ℹ no frontend or a build already exists, skipping frontend build for 'application'
✔ Deployed 36 action(s) for 'application'
no frontend, skipping frontend deploy 'application'
Your deployed actions:
web actions:
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/web/starter-kit/info 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/web/webhook/check-stock 
non-web actions:
  -> starter-kit/__secured_info 
  -> webhook/__secured_check-stock 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-commerce/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-commerce/created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-commerce/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-commerce/deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-backoffice/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-backoffice/created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-backoffice/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/product-backoffice/deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/group-updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-commerce/group-deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/group-created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/group-updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/customer-backoffice/group-deleted 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-commerce/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-commerce/created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-commerce/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-backoffice/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-backoffice/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-backoffice/shipment-created 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/order-backoffice/shipment-updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/stock-commerce/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/stock-commerce/updated 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/stock-backoffice/consumer 
  -> https://1340225-node20test-stage.adobeioruntime.net/api/v1/stock-backoffice/updated 
Starting the process of on-boarding based on you registration choice
Starting the commerce event subscribe process
skipping publish phase...
Successful deployment 🏄
(node:19159) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
⠴ Getting Enterprise Credentials attached to Workspace Stage...Start process of creating providers:  {
  product: {
    commerce: [
      'com.adobe.commerce.observer.catalog_product_delete_commit_after',
      'com.adobe.commerce.observer.catalog_product_save_commit_after'
    ],
    backoffice: [
      'be-observer.catalog_product_create',
      'be-observer.catalog_product_update',
      'be-observer.catalog_product_delete'
    ]
  },
  customer: {
    commerce: [
      'com.adobe.commerce.observer.customer_save_commit_after',
      'com.adobe.commerce.observer.customer_delete_commit_after',
      'com.adobe.commerce.observer.customer_group_save_commit_after',
      'com.adobe.commerce.observer.customer_group_delete_commit_after'
    ],
    backoffice: [
      'be-observer.customer_create',
      'be-observer.customer_update',
      'be-observer.customer_delete',
      'be-observer.customer_group_create',
      'be-observer.customer_group_update',
      'be-observer.customer_group_delete'
    ]
  },
  order: {
    commerce: [ 'com.adobe.commerce.observer.sales_order_save_commit_after' ],
    backoffice: [
      'be-observer.sales_order_status_update',
      'be-observer.sales_order_shipment_create',
      'be-observer.sales_order_shipment_update'
    ]
  },
  stock: {
    commerce: [
      'com.adobe.commerce.observer.cataloginventory_stock_item_save_commit_after'
    ],
    backoffice: [ 'be-observer.catalog_stock_update' ]
  }
}
Skipping creation of "Commerce Provider - node20test-stage" creation
Skipping creation of "Backoffice Provider - node20test-stage" creation
Defining the commerce provider id as : 09f11eb4-34d4-4baa-a98e-48015b9077b8
Defining the backoffice provider id as : d1e826c5-dd52-4cf1-8220-ef1fa2c8857a
200: Process of creating providers done successfully
Skipping, Metadata event code com.adobe.commerce.observer.catalog_product_delete_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.catalog_product_save_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.customer_save_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.customer_delete_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.customer_group_save_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.customer_group_delete_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.sales_order_save_commit_after already exists!
Skipping, Metadata event code com.adobe.commerce.observer.cataloginventory_stock_item_save_commit_after already exists!
Successfully subscribed to event: observer.catalog_product_delete_commit_after
Skipping, Metadata event code be-observer.catalog_product_create already exists!
Skipping, Metadata event code be-observer.catalog_product_update already exists!
Skipping, Metadata event code be-observer.catalog_product_delete already exists!
Skipping, Metadata event code be-observer.customer_create already exists!
Skipping, Metadata event code be-observer.customer_update already exists!
Skipping, Metadata event code be-observer.customer_delete already exists!
Skipping, Metadata event code be-observer.customer_group_create already exists!
Skipping, Metadata event code be-observer.customer_group_update already exists!
Skipping, Metadata event code be-observer.customer_group_delete already exists!
Skipping, Metadata event code be-observer.sales_order_status_update already exists!
Skipping, Metadata event code be-observer.sales_order_shipment_create already exists!
Skipping, Metadata event code be-observer.sales_order_shipment_update already exists!
Skipping, Metadata event code be-observer.catalog_stock_update already exists!
200: Process of adding metadata to provider done successfully
Successfully subscribed to event: observer.catalog_product_save_commit_after
Start creating registrations for the provider: Commerce Provider - node20test-stage
Registration Commerce Product Synchronization already exists for entity product - commerce
Registration Commerce Customer Synchronization already exists for entity customer - commerce
Registration Commerce Order Synchronization already exists for entity order - commerce
Registration Commerce Stock Synchronization already exists for entity stock - commerce
Start creating registrations for the provider: Backoffice Provider - node20test-stage
Registration Backoffice Product Synchronization already exists for entity product - backoffice
Registration Backoffice Customer Synchronization already exists for entity customer - backoffice
Registration Backoffice Order Synchronization already exists for entity order - backoffice
Registration Backoffice Stock Synchronization already exists for entity stock - backoffice
Create registrations process done correctly!
Created registrations:  [
  {
    id: 1534729,
    registration_id: 'de7d95af-d01e-48fa-9f14-f8c7832b2216',
    name: 'Commerce Product Synchronization',
    enabled: true
  },
  {
    id: 1534730,
    registration_id: 'aa945c5b-1f58-4b02-b139-fa651d21046f',
    name: 'Commerce Customer Synchronization',
    enabled: true
  },
  {
    id: 1534731,
    registration_id: '9bf2f9e3-197d-4311-b0c8-862a0b3dc905',
    name: 'Commerce Order Synchronization',
    enabled: true
  },
  {
    id: 1534732,
    registration_id: '09d56d9e-c4c0-434a-aac4-ad777685b8f7',
    name: 'Commerce Stock Synchronization',
    enabled: true
  },
  {
    id: 1534733,
    registration_id: '0b2ddd51-e123-4f3e-966e-8ed898f5a809',
    name: 'Backoffice Product Synchronization',
    enabled: true
  },
  {
    id: 1534734,
    registration_id: '19f769f1-3a98-44c2-a9de-911f5bb14ac2',
    name: 'Backoffice Customer Synchronization',
    enabled: true
  },
  {
    id: 1534735,
    registration_id: 'ffade191-1de0-4011-814a-4d364b21ded4',
    name: 'Backoffice Order Synchronization',
    enabled: true
  },
  {
    id: 1534736,
    registration_id: 'c3e7693d-5aa8-486c-8728-be5b3810955e',
    name: 'Backoffice Stock Synchronization',
    enabled: true
  }
]
Process of On-Boarding done successfully: [
  {
    key: 'commerce',
    id: '09f11eb4-34d4-4baa-a98e-48015b9077b8',
    instanceId: 'c53444ab-d4e2-41c0-9b99-53bc37962d22',
    label: 'Commerce Provider - node20test-stage'
  },
  {
    key: 'backoffice',
    id: 'd1e826c5-dd52-4cf1-8220-ef1fa2c8857a',
    instanceId: 'e8606aa5-e8e7-40f3-b76f-6b0b99ca452a',
    label: 'Backoffice Provider - node20test-stage'
  }
]
Starting the process of configuring Adobe I/O Events module in Commerce
Successfully subscribed to event: observer.customer_save_commit_after
Process of configuring Adobe I/O Events module in Commerce completed successfully
Successfully subscribed to event: observer.customer_delete_commit_after
Successfully subscribed to event: observer.customer_group_save_commit_after
Successfully subscribed to event: observer.customer_group_delete_commit_after
Successfully subscribed to event: observer.sales_order_save_commit_after
Successfully subscribed to event: observer.cataloginventory_stock_item_save_commit_after
Finished the commerce event subscribe process with result {
  successful_subscriptions: [
    'observer.catalog_product_delete_commit_after',
    'observer.catalog_product_save_commit_after',
    'observer.customer_save_commit_after',
    'observer.customer_delete_commit_after',
    'observer.customer_group_save_commit_after',
    'observer.customer_group_delete_commit_after',
    'observer.sales_order_save_commit_after',
    'observer.cataloginventory_stock_item_save_commit_after'
  ],
  failed_subscriptions: []
}
 
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
