### PR TITLE
ACSP-231 Change event registration names in the onboarding script

### DIFF
--- a/test/scripts/lib/onboarding.registrations.test.js
+++ b/test/scripts/lib/onboarding.registrations.test.js
@@ -49,7 +49,7 @@ describe('Given on-boarding registrations file', () => {
         json: () => Promise.resolve(
           {
             id: 1,
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             description: 'string',
             client_id: 'CLIENT_ID',
             registration_id: 'REGISTRATION_ID_1',
@@ -213,7 +213,7 @@ describe('Given on-boarding registrations file', () => {
         json: () => Promise.resolve(
           {
             id: 2,
-            name: 'Backoffice Product Synchronization',
+            name: 'Backoffice Product Sync',
             description: 'string',
             client_id: 'CLIENT_ID',
             registration_id: 'REGISTRATION_ID_2',
@@ -258,13 +258,13 @@ describe('Given on-boarding registrations file', () => {
           {
             id: 1,
             registration_id: 'REGISTRATION_ID_1',
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             enabled: true
           },
           {
             id: 2,
             registration_id: 'REGISTRATION_ID_2',
-            name: 'Backoffice Product Synchronization',
+            name: 'Backoffice Product Sync',
             enabled: true
           }
         ]
@@ -407,7 +407,7 @@ describe('Given on-boarding registrations file', () => {
         json: () => Promise.resolve(
           {
             id: 1,
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             description: 'string',
             client_id: 'CLIENT_ID',
             registration_id: 'REGISTRATION_ID_1',
@@ -451,7 +451,7 @@ describe('Given on-boarding registrations file', () => {
           {
             id: 1,
             registration_id: 'REGISTRATION_ID_1',
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             enabled: true
           }
         ]
@@ -594,7 +594,7 @@ describe('Given on-boarding registrations file', () => {
         json: () => Promise.resolve(
           {
             id: 2,
-            name: 'Backoffice Product Synchronization',
+            name: 'Backoffice Product Sync',
             description: 'string',
             client_id: 'CLIENT_ID',
             registration_id: 'REGISTRATION_ID_2',
@@ -638,7 +638,7 @@ describe('Given on-boarding registrations file', () => {
           {
             id: 2,
             registration_id: 'REGISTRATION_ID_2',
-            name: 'Backoffice Product Synchronization',
+            name: 'Backoffice Product Sync',
             enabled: true
           }
         ]
@@ -708,7 +708,7 @@ describe('Given on-boarding registrations file', () => {
               registrations: [
                 {
                   id: 2,
-                  name: 'Backoffice Product Synchronization',
+                  name: 'Backoffice Product Sync',
                   description: 'string',
                   client_id: 'string',
                   registration_id: 'EXISTING_BACKOFFICE_ID',
@@ -781,7 +781,7 @@ describe('Given on-boarding registrations file', () => {
         json: () => Promise.resolve(
           {
             id: 1,
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             description: 'string',
             client_id: 'CLIENT_ID',
             registration_id: 'CREATED_REGISTRATION_ID',
@@ -825,13 +825,13 @@ describe('Given on-boarding registrations file', () => {
           {
             id: 1,
             registration_id: 'CREATED_REGISTRATION_ID',
-            name: 'Commerce Product Synchronization',
+            name: 'Commerce Product Sync',
             enabled: true
           },
           {
             id: 2,
             registration_id: 'EXISTING_BACKOFFICE_ID',
-            name: 'Backoffice Product Synchronization',
+            name: 'Backoffice Product Sync',
             enabled: true
           }
         ]

--- a/test/utils/naming.test.js
+++ b/test/utils/naming.test.js
@@ -51,13 +51,13 @@ describe('Given naming file', () => {
   })
   describe('When getRegistrationName is called', () => {
     const cases = Object.keys(events).flatMap(entityName =>
-        providers.map(({ key: providerKey }) => ({ providerKey, entityName }))
-    );
+      providers.map(({ key: providerKey }) => ({ providerKey, entityName }))
+    )
 
-    test.each(cases)("naming.getRegistrationName($providerKey, $entityName) returns strings with 25 or less chars",
-        ({ providerKey, entityName }) => {
-      const result = naming.getRegistrationName(providerKey, entityName);
-      expect(result.length).toBeLessThanOrEqual(25)
-    })
+    test.each(cases)('naming.getRegistrationName($providerKey, $entityName) returns strings with 25 or less chars',
+      ({ providerKey, entityName }) => {
+        const result = naming.getRegistrationName(providerKey, entityName)
+        expect(result.length).toBeLessThanOrEqual(25)
+      })
   })
 })

--- a/test/utils/naming.test.js
+++ b/test/utils/naming.test.js
@@ -49,7 +49,7 @@ describe('Given naming file', () => {
       expect(naming.addSuffix(label, environment)).toEqual('Label - testProject-testWorkspace')
     })
   })
-  describe('When getRegistrationname is called', () => {
+  describe('When getRegistrationName is called', () => {
     Object.keys(events).forEach(entityName => {
       providers.forEach(provider => {
         test('Then returns a string of 25 characters or less', () => {

--- a/test/utils/naming.test.js
+++ b/test/utils/naming.test.js
@@ -50,14 +50,14 @@ describe('Given naming file', () => {
     })
   })
   describe('When getRegistrationName is called', () => {
-    Object.keys(events).forEach(entityName => {
-      providers.forEach(provider => {
-        test('Then returns a string of 25 characters or less', () => {
-          const providerKey = provider.key
-          const result = naming.getRegistrationName(providerKey, entityName)
-          expect(result.length).toBeLessThanOrEqual(25)
-        })
-      })
+    const cases = Object.keys(events).flatMap(entityName =>
+        providers.map(({ key: providerKey }) => ({ providerKey, entityName }))
+    );
+
+    test.each(cases)("naming.getRegistrationName($providerKey, $entityName) returns strings with 25 or less chars",
+        ({ providerKey, entityName }) => {
+      const result = naming.getRegistrationName(providerKey, entityName);
+      expect(result.length).toBeLessThanOrEqual(25)
     })
   })
 })

--- a/test/utils/naming.test.js
+++ b/test/utils/naming.test.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const naming = require('../../utils/naming.js')
+const providers = require('../../scripts/onboarding/config/providers.json')
+const events = require('../../scripts/onboarding/config/events.json')
 
 describe('Given naming file', () => {
   describe('When method addSufix is called with label parameter undefined', () => {
@@ -45,6 +47,17 @@ describe('Given naming file', () => {
       const label = 'Label'
       const environment = { AIO_runtime_namespace: '1340225-testProject-testWorkspace' }
       expect(naming.addSuffix(label, environment)).toEqual('Label - testProject-testWorkspace')
+    })
+  })
+  describe('When getRegistrationname is called', () => {
+    Object.keys(events).forEach(entityName => {
+      providers.forEach(provider => {
+        test('Then returns a string of 25 characters or less', () => {
+          const providerKey = provider.key
+          const result = naming.getRegistrationName(providerKey, entityName)
+          expect(result.length).toBeLessThanOrEqual(25)
+        })
+      })
     })
   })
 })

--- a/utils/naming.js
+++ b/utils/naming.js
@@ -57,7 +57,7 @@ function stringToUppercaseFirstChar (string) {
  * @returns {string} the generated registration name
  */
 function getRegistrationName (providerKey, entityName) {
-  return `${stringToUppercaseFirstChar(providerKey)} ${stringToUppercaseFirstChar(entityName)} Synchronization`
+  return `${stringToUppercaseFirstChar(providerKey)} ${stringToUppercaseFirstChar(entityName)} Sync`
 }
 
 /**


### PR DESCRIPTION
## Description

Change event registration names in the onboarding script from `<providerKey> <entityName> Synchronization` to `<providerKey> <entityName> Sync`

## Related Issue

https://github.com/adobe/commerce-integration-starter-kit/issues/14

## Motivation and Context

The onboarding script needs to create event registrations with names that can pass frontend validation so they can be modified in Adobe console without changing the name.

## How Has This Been Tested?

The change has been tested by deploying and onboarding a starter-kit-based App Builder project

## Screenshots (if appropriate):

![EventRegistrationDetails](https://github.com/user-attachments/assets/52aa0183-6870-43c1-b09f-301e9b7cdda8)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
