### PR TITLE
INTERNAL - make `sales_order_save_commit_after` sample event compliant with validation schema

### DIFF
--- a/scripts/onboarding/config/events.json
+++ b/scripts/onboarding/config/events.json
@@ -174,13 +174,10 @@
               "carrierCode": "custom"
             }
           ],
-          "comments": [
-            {
-              "notifyCustomer": false,
+          "comment": {
               "comment": "Order Shipped in Backoffice",
               "visibleOnFront": true
-            }
-          ],
+            },
           "stockSourceCode": "default"
         }
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Make `sales_order_save_commit_after` sample event compliant with its JSON schema.
Currently, it yields a validation error caused by not matching the JSON validation defined in the runtime action code.
![image](https://github.com/user-attachments/assets/6fbf8325-e9fd-4fde-8508-fda93ba888a4)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The sample event should be compliant with the JSON schema defined by the action that will process it, otherwise, if triggered from the Adobe Developer Console, it'll yield an HTTP/400 response related to invalid event format

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The fix has been tested in a fresh deployment of the starter kit.

## Screenshots (if appropriate):
The new sample event as displayed on the Adobe Developer Console:
![image](https://github.com/user-attachments/assets/b9eeb6b3-b25b-452d-9325-0c71407c6c0a)

The new sample event is processed by the corresponding registration. The processing still yields an HTTP/400 error, but now it is not related to the event validation.
![image](https://github.com/user-attachments/assets/9dff9076-d5af-47d1-a11a-f63ccf901956)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
