### PR TITLE
Issue-26 - Could not find the COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID env value with provided instructions

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -21,6 +21,9 @@ COMMERCE_ACCESS_TOKEN_SECRET=
 # Commerce Event Module configs
 # These values will be used to configure the Adobe I/O Events module automatically
 # that can be found at Stores > Configuration > Adobe Services > Adobe I/O Events
+#
+# Set the COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID property to the merchant's company name.
+# Note that the value can only contain alphanumeric characters and underscores.
 COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID=
 
 # Workspace configs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improve documentation in the `env.dist` about the `COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID` property

- what it is
- what value to use
- what are the constraints

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/commerce-integration-starter-kit/issues/26

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Help with installation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
