### PR TITLE
INTERNAL - [Addendum] Improve error messages

### DIFF
--- a/scripts/commerce-event-subscribe/index.js
+++ b/scripts/commerce-event-subscribe/index.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const ansis = require('ansis')
-const { makeError } = require('../lib/helpers/errors')
+const { makeError, formatError } = require('../lib/helpers/errors')
 
 require('dotenv').config()
 
@@ -22,14 +22,15 @@ require('dotenv').config()
 function logCommerceEventSubscribeError (errorInfo) {
   const { label, reason, payload } = errorInfo
   const additionalDetails = payload
-    ? JSON.stringify(payload, null, 2)
+    ? formatError(payload)
     : 'No additional details'
 
   console.error(
+    ansis.red('\nAn error occurred:\n'),
     ansis.bgRed(`\n COMMERCE_EVENT_SUBSCRIBE → ${label} \n`),
     ansis.red('\nProcess of subscribing to events in the Adobe I/O Events module in Commerce failed:\n'),
-    reason,
-    ansis.red(`\nAdditional error details:" ${additionalDetails}\n`)
+    ansis.red(reason),
+    ansis.red(`\nAdditional error details: ${additionalDetails}\n`)
   )
 }
 

--- a/scripts/lib/helpers/errors.js
+++ b/scripts/lib/helpers/errors.js
@@ -1,3 +1,5 @@
+const util = require('node:util')
+
 const LAST_RETURN_CHAR = '└── '
 const RETURN_CHAR = '├── '
 
@@ -35,7 +37,25 @@ function makeError (label, reason, payload = {}) {
   }
 }
 
+/**
+ * Format an error object to be logged to the console.
+ * It uses util.inspect to format the error object and log at maximum depth.
+ *
+ * @param {object} error - The error object to format.
+ */
+function formatError (error) {
+  return (
+    util.inspect(error, {
+      sorted: true,
+      depth: null,
+      colors: true,
+      maxStringLength: Number.POSITIVE_INFINITY
+    })
+  )
+}
+
 module.exports = {
   makeError,
-  arrayItemsErrorFormat
+  arrayItemsErrorFormat,
+  formatError
 }

--- a/scripts/onboarding/index.js
+++ b/scripts/onboarding/index.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const ansis = require('ansis')
 const { getAdobeAccessToken } = require('../../utils/adobe-auth')
-const { makeError } = require('../lib/helpers/errors')
+const { makeError, formatError } = require('../lib/helpers/errors')
 
 require('dotenv').config()
 
@@ -30,14 +30,15 @@ function logOnboardingError (phase, errorInfo) {
   }
 
   const additionalDetails = payload
-    ? JSON.stringify(payload, null, 2)
+    ? formatError(payload)
     : 'No additional details'
 
   console.error(
+    ansis.red('\nAn error occurred:\n'),
     ansis.bgRed(`\n ${phaseLabels[phase]} → ${label} \n`),
     ansis.red(`\nProcess of on-boarding (${phase}) failed:\n`),
-    reason,
-    ansis.red(`\nAdditional error details:" ${additionalDetails}\n`)
+    ansis.red(reason),
+    ansis.red(`\nAdditional error details: ${additionalDetails}\n`)
   )
 }
 
@@ -48,14 +49,15 @@ function logOnboardingError (phase, errorInfo) {
 function logConfigureEventingError (errorInfo) {
   const { label, reason, payload } = errorInfo
   const additionalDetails = payload
-    ? JSON.stringify(payload, null, 2)
+    ? formatError(payload)
     : 'No additional details'
 
   console.error(
+    ansis.red('\nAn error occurred:\n'),
     ansis.bgRed(`\n CONFIGURE_EVENTING → ${label} \n`),
     ansis.red('\nProcess of configuring Adobe I/O Events module in Commerce failed:\n'),
-    reason,
-    ansis.red(`\nAdditional error details:" ${additionalDetails}\n`)
+    ansis.red(reason),
+    ansis.red(`\nAdditional error details: ${additionalDetails}\n`)
   )
 }
 


### PR DESCRIPTION
## Description

This PR is an addendum to #55, it improves error logging by replacing `JSON.stringify` which is [not able to serialize errors](https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify), with `util.inspect`.