### PR TITLE
CEXT-5226: Replace unsupported state key chars in product skus

### DIFF
--- a/actions/product/commerce/consumer/index.js
+++ b/actions/product/commerce/consumer/index.js
@@ -20,7 +20,6 @@ const {
   HTTP_BAD_REQUEST,
   HTTP_OK,
   HTTP_INTERNAL_ERROR,
-  INVALID_STATE_KEY_CHARS_REGEX,
 } = require("../../../constants");
 
 const Openwhisk = require("../../../openwhisk");
@@ -53,11 +52,7 @@ function fnFingerprint(params) {
  */
 function fnInfiniteLoopKey(params) {
   return () => {
-    const sanitizedSku = params.data.value.sku.replace(
-      INVALID_STATE_KEY_CHARS_REGEX,
-      "_",
-    );
-    return `ilk_${sanitizedSku}`;
+    return `ilk_${params.data.value.sku}`;
   };
 }
 

--- a/actions/product/external/consumer/index.js
+++ b/actions/product/external/consumer/index.js
@@ -19,7 +19,6 @@ const {
   HTTP_INTERNAL_ERROR,
   HTTP_BAD_REQUEST,
   HTTP_OK,
-  INVALID_STATE_KEY_CHARS_REGEX,
 } = require("../../../constants");
 const Openwhisk = require("../../../openwhisk");
 const { errorResponse, successResponse } = require("../../../responses");
@@ -50,11 +49,7 @@ function fnFingerprint(params) {
  */
 function fnInfiniteLoopKey(params) {
   return () => {
-    const sanitizedSku = params.data.value.sku.replace(
-      INVALID_STATE_KEY_CHARS_REGEX,
-      "_",
-    );
-    return `ilk_${sanitizedSku}`;
+    return `ilk_${params.data.value.sku}`;
   };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds replacement of characters in product SKUs that are not supported in aio-lib-state keys

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[CEXT-5226](https://jira.corp.adobe.com/browse/CEXT-5226)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Before this change, errors occurred when a product with a sku containing unsupported characters was saved. For example, when saving a product with a sku like "Simple/Product" in the Adobe Commerce admin (although the slash may be uncommon in a SKU, it is technically supported by Commerce), for example, resulted in errors like the following:
```
[AdobeStateLib:ERROR_BAD_ARGUMENT] /key must match pattern \"^[a-zA-Z0-9-_.]{1,1024}$\"
```
due to the generated infinite loop key containing an unsupported space character and being passed to aio-state-lib functions

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested by saving a product with the sku "Simple/Product" in the admin of an ACCS instance after installing and configuring the starter kit. The change in this PR in the product consumer action's `fnInfiniteLoopKey` function was temporarily removed and the app was redeployed. The debug tracing tab for [this registration](https://developer.adobe.com/console/projects/3117813/4566206088345489896/workspaces/4566206088345527420/events/2674168/details) showed errors containing the lib state key pattern message. After seeing the error, the change was added back in and the product consumer action was redeployed again. When the event was retried, a 200 response code was seen in the debug tracing tab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
