### PR TITLE
upgrade biome to 2.4.13 and ultracite to 7.6.2

### DIFF
--- a/actions/auth.js
+++ b/actions/auth.js
@@ -21,13 +21,11 @@ const logger = Core.Logger("auth", { level: "info" });
 function checkIfMissing(params, expected) {
   return expected
     .filter((value) => !params[value])
-    .map((key) => {
-      return {
-        error: true,
-        message: `Missing ${key} in params`,
-        key,
-      };
-    });
+    .map((key) => ({
+      error: true,
+      message: `Missing ${key} in params`,
+      key,
+    }));
 }
 
 /**

--- a/actions/customer/commerce/metrics.js
+++ b/actions/customer/commerce/metrics.js
@@ -2,27 +2,25 @@ const { defineMetrics } = require("@adobe/aio-lib-telemetry");
 const { ValueType } = require("@adobe/aio-lib-telemetry/otel");
 
 /** Metrics used across all actions. */
-const commerceCustomerMetrics = defineMetrics((meter) => {
-  return {
-    consumerSuccessCounter: meter.createCounter(
-      "customer.commerce.consumer.success_count",
-      {
-        description:
-          "A counter for the number of successful Commerce Customer Consumer actions.",
-        valueType: ValueType.INT,
-      },
-    ),
+const commerceCustomerMetrics = defineMetrics((meter) => ({
+  consumerSuccessCounter: meter.createCounter(
+    "customer.commerce.consumer.success_count",
+    {
+      description:
+        "A counter for the number of successful Commerce Customer Consumer actions.",
+      valueType: ValueType.INT,
+    },
+  ),
 
-    consumerTotalCounter: meter.createCounter(
-      "customer.commerce.consumer.total_count",
-      {
-        description:
-          "A counter for the number of total Commerce Customer Consumer actions.",
-        valueType: ValueType.INT,
-      },
-    ),
-  };
-});
+  consumerTotalCounter: meter.createCounter(
+    "customer.commerce.consumer.total_count",
+    {
+      description:
+        "A counter for the number of total Commerce Customer Consumer actions.",
+      valueType: ValueType.INT,
+    },
+  ),
+}));
 
 module.exports = {
   commerceCustomerMetrics,

--- a/actions/oauth1a.js
+++ b/actions/oauth1a.js
@@ -39,7 +39,7 @@ function createClient(options, authOptions, logger) {
   const serverUrl = options.url;
   const apiVersion = options.version;
 
-  let getAuthorizationHeaders = (opts) => {
+  let getAuthorizationHeaders = (_opts) => {
     throw new Error("getAuthorizationHeaders not implemented");
   };
 
@@ -58,8 +58,8 @@ function createClient(options, authOptions, logger) {
       secret: commerceOAuth1.accessTokenSecret,
     };
     const oauth = getOAuthHeader(commerceOAuth1);
-    getAuthorizationHeaders = ({ url, method }) => {
-      return oauth.toHeader(
+    getAuthorizationHeaders = ({ url, method }) =>
+      oauth.toHeader(
         oauth.authorize(
           {
             url,
@@ -68,7 +68,6 @@ function createClient(options, authOptions, logger) {
           oauthToken,
         ),
       );
-    };
   }
 
   /**

--- a/actions/product/commerce/consumer/index.js
+++ b/actions/product/commerce/consumer/index.js
@@ -37,12 +37,10 @@ const {
  * @returns the function that generates the fingerprint
  */
 function fnFingerprint(params) {
-  return () => {
-    return {
-      product: params.data.value.sku,
-      description: params.data.value.description,
-    };
-  };
+  return () => ({
+    product: params.data.value.sku,
+    description: params.data.value.description,
+  });
 }
 
 /**
@@ -51,9 +49,7 @@ function fnFingerprint(params) {
  * @returns the function that generates the keu
  */
 function fnInfiniteLoopKey(params) {
-  return () => {
-    return `ilk_${params.data.value.sku}`;
-  };
+  return () => `ilk_${params.data.value.sku}`;
 }
 
 /**

--- a/actions/product/commerce/full-sync/index.js
+++ b/actions/product/commerce/full-sync/index.js
@@ -74,7 +74,6 @@ async function main(params) {
     }
 
     const message = [
-      // biome-ignore lint/nursery/noUnnecessaryConditions: seems to be a false positive
       `Sync process ${hasErrors ? "completed with some errors" : "completed successfully"}.`,
       `Processed ${results.length} pages:`,
       `\t${results.filter((item) => item.success).length} succeeded.`,

--- a/actions/product/external/consumer/index.js
+++ b/actions/product/external/consumer/index.js
@@ -34,12 +34,10 @@ const {
  * @returns the function that generates the fingerprint
  */
 function fnFingerprint(params) {
-  return () => {
-    return {
-      product: params.data.value.sku,
-      description: params.data.value.description,
-    };
-  };
+  return () => ({
+    product: params.data.value.sku,
+    description: params.data.value.description,
+  });
 }
 
 /**
@@ -48,9 +46,7 @@ function fnFingerprint(params) {
  * @returns the function that generates the keu
  */
 function fnInfiniteLoopKey(params) {
-  return () => {
-    return `ilk_${params.data.value.sku}`;
-  };
+  return () => `ilk_${params.data.value.sku}`;
 }
 
 /**

--- a/actions/telemetry.js
+++ b/actions/telemetry.js
@@ -5,19 +5,17 @@ const {
 } = require("@adobe/aio-lib-telemetry");
 
 /** The telemetry configuration to be used across all actions */
-const telemetryConfig = defineTelemetryConfig((params, isDev) => {
-  return {
-    sdkConfig: {
-      serviceName: "commerce-integration-starter-kit",
-      resource: getAioRuntimeResource(),
-      instrumentations: getPresetInstrumentations("simple"),
-    },
+const telemetryConfig = defineTelemetryConfig((_params, isDev) => ({
+  sdkConfig: {
+    serviceName: "commerce-integration-starter-kit",
+    resource: getAioRuntimeResource(),
+    instrumentations: getPresetInstrumentations("simple"),
+  },
 
-    diagnostics: {
-      logLevel: isDev ? "debug" : "info",
-    },
-  };
-});
+  diagnostics: {
+    logLevel: isDev ? "debug" : "info",
+  },
+}));
 
 /**
  * Helper function used within the Starter Kit to determine if an instrumented action is successful.

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -31,11 +31,7 @@ function stringParameters(params) {
   // hide parameters including terms in the 'hidden' array
   let sanitizedParams = { ...params };
   for (const key of Object.keys(sanitizedParams)) {
-    if (
-      !hidden.every((v) => {
-        return key.toLowerCase().indexOf(v) === -1;
-      })
-    ) {
+    if (!hidden.every((v) => key.toLowerCase().indexOf(v) === -1)) {
       sanitizedParams = { ...sanitizedParams, [key]: "<hidden>" };
     }
   }
@@ -105,7 +101,6 @@ function checkMissingRequestInputs(
   // check for missing parameters
   const missingParams = getMissingKeys(params, requiredParams);
   if (missingParams.length > 0) {
-    // biome-ignore lint/nursery/noUnnecessaryConditions: Seems to be a false positive.
     if (errorMessage) {
       errorMessage += " and ";
     } else {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
-  "extends": ["ultracite/core"],
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "extends": ["ultracite/biome/core"],
 
   "files": {
     "ignoreUnknown": true

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
-  "extends": ["ultracite"],
+  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "extends": ["ultracite/core"],
 
   "files": {
     "ignoreUnknown": true
@@ -32,6 +32,10 @@
       },
       "performance": {
         "noNamespaceImport": "off"
+      },
+      "correctness": {
+        // This is a CJS project; __dirname is valid and import.meta.dirname is not available.
+        "noGlobalDirnameFilename": "off"
       }
     }
   },
@@ -45,10 +49,6 @@
             "noExcessiveCognitiveComplexity": "off"
           },
 
-          "nursery": {
-            "useMaxParams": "off"
-          },
-
           "suspicious": {
             // We use console to log information during the onboarding process.
             "noConsole": "off"
@@ -60,10 +60,6 @@
       "includes": ["actions/**/*.js"],
       "linter": {
         "rules": {
-          "nursery": {
-            "useMaxParams": "off"
-          },
-
           "suspicious": {
             // Some placeholder functions most likely will be async (they invoke external systems), but they are unimplemented
             // so they don't use await. This is left to warn, because implementers should be aware of this.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,13 @@
         "valibot": "^1.1.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.3.15",
+        "@biomejs/biome": "2.4.13",
         "husky": "9.1.7",
         "jest": "29.7.0",
         "lint-staged": "16.1.5",
         "nock": "13.5.6",
         "prettier": "3.6.2",
-        "ultracite": "6.5.1"
+        "ultracite": "7.6.2"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1293,9 +1293,9 @@
       "license": "MIT"
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.15.tgz",
-      "integrity": "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1309,20 +1309,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.15",
-        "@biomejs/cli-darwin-x64": "2.3.15",
-        "@biomejs/cli-linux-arm64": "2.3.15",
-        "@biomejs/cli-linux-arm64-musl": "2.3.15",
-        "@biomejs/cli-linux-x64": "2.3.15",
-        "@biomejs/cli-linux-x64-musl": "2.3.15",
-        "@biomejs/cli-win32-arm64": "2.3.15",
-        "@biomejs/cli-win32-x64": "2.3.15"
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.15.tgz",
-      "integrity": "sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
       "cpu": [
         "arm64"
       ],
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.15.tgz",
-      "integrity": "sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
       "cpu": [
         "x64"
       ],
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.15.tgz",
-      "integrity": "sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
       "cpu": [
         "arm64"
       ],
@@ -1371,9 +1371,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.15.tgz",
-      "integrity": "sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
       "cpu": [
         "arm64"
       ],
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.15.tgz",
-      "integrity": "sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
       "cpu": [
         "x64"
       ],
@@ -1405,9 +1405,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.15.tgz",
-      "integrity": "sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
       "cpu": [
         "x64"
       ],
@@ -1422,9 +1422,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.15.tgz",
-      "integrity": "sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
       "cpu": [
         "arm64"
       ],
@@ -1439,9 +1439,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.15.tgz",
-      "integrity": "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
       "cpu": [
         "x64"
       ],
@@ -1456,25 +1456,26 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
+        "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
-      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "0.5.0",
-        "picocolors": "^1.0.0",
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
     },
@@ -4239,22 +4240,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@trpc/server": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.16.0.tgz",
-      "integrity": "sha512-XgGuUMddrUTd04+za/WE5GFuZ1/YU9XQG0t3VL5WOIu2JspkOlq6k4RYEiqS6HSJt+S0RXaPdIoE2anIP/BBRQ==",
-      "dev": true,
-      "funding": [
-        "https://trpc.io/sponsor"
-      ],
-      "license": "MIT",
-      "bin": {
-        "intent": "bin/intent.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.7.2"
-      }
-    },
     "node_modules/@tsconfig/node22": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.0.tgz",
@@ -5470,9 +5455,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6023,6 +6008,23 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -6038,6 +6040,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -10171,50 +10183,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/trpc-cli": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/trpc-cli/-/trpc-cli-0.12.4.tgz",
-      "integrity": "sha512-Yo2Ob5J7hUZSWZ2A1M9Kb+0qfSxwmcmYIs3kkQyLd3sn0qU4ryGzNsySfrY3+urqp6FnDnIIdbCSqC9BKxK6Ag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "commander": "^14.0.0"
-      },
-      "bin": {
-        "trpc-cli": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@orpc/server": "^1.0.0",
-        "@trpc/server": "^10.45.2 || ^11.0.1",
-        "@valibot/to-json-schema": "^1.1.0",
-        "effect": "^3.14.2 || ^4.0.0",
-        "valibot": "^1.1.0",
-        "zod": "^3.24.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@orpc/server": {
-          "optional": true
-        },
-        "@trpc/server": {
-          "optional": true
-        },
-        "@valibot/to-json-schema": {
-          "optional": true
-        },
-        "effect": {
-          "optional": true
-        },
-        "valibot": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -10267,24 +10235,36 @@
       }
     },
     "node_modules/ultracite": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-6.5.1.tgz",
-      "integrity": "sha512-PeS2L9L4EDINVVUHW+H/pnmidCetWX2a9/baF+C7Foi3hF3lKLRn5oaBjaP7FGTURcTwfeoZg0ZaYB7ULDdtxQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-7.6.2.tgz",
+      "integrity": "sha512-HonD+l9o8bFEUcVLlefpg5JuvaZH/UTB0jpCVtKAZ6xV1LGZj/hq4nGlz/eezIMmFfd6fe43LMxn1CaY/N/LaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clack/prompts": "^0.11.0",
-        "@trpc/server": "^11.8.0",
+        "@clack/prompts": "^1.2.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
         "deepmerge": "^4.3.1",
-        "glob": "^13.0.0",
+        "glob": "^13.0.6",
         "jsonc-parser": "^3.3.1",
-        "nypm": "^0.6.2",
-        "picocolors": "^1.1.1",
-        "trpc-cli": "^0.12.1",
-        "zod": "^4.1.13"
+        "nypm": "^0.6.5",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
       },
       "bin": {
         "ultracite": "dist/index.js"
+      },
+      "peerDependencies": {
+        "oxfmt": ">=0.1.0",
+        "oxlint": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxfmt": {
+          "optional": true
+        },
+        "oxlint": {
+          "optional": true
+        }
       }
     },
     "node_modules/ultracite/node_modules/balanced-match": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,13 +29,13 @@
         "valibot": "^1.1.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.2.0",
+        "@biomejs/biome": "2.3.15",
         "husky": "9.1.7",
         "jest": "29.7.0",
         "lint-staged": "16.1.5",
         "nock": "13.5.6",
         "prettier": "3.6.2",
-        "ultracite": "5.2.3"
+        "ultracite": "6.5.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1293,9 +1293,9 @@
       "license": "MIT"
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.0.tgz",
-      "integrity": "sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.15.tgz",
+      "integrity": "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1309,20 +1309,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.2.0",
-        "@biomejs/cli-darwin-x64": "2.2.0",
-        "@biomejs/cli-linux-arm64": "2.2.0",
-        "@biomejs/cli-linux-arm64-musl": "2.2.0",
-        "@biomejs/cli-linux-x64": "2.2.0",
-        "@biomejs/cli-linux-x64-musl": "2.2.0",
-        "@biomejs/cli-win32-arm64": "2.2.0",
-        "@biomejs/cli-win32-x64": "2.2.0"
+        "@biomejs/cli-darwin-arm64": "2.3.15",
+        "@biomejs/cli-darwin-x64": "2.3.15",
+        "@biomejs/cli-linux-arm64": "2.3.15",
+        "@biomejs/cli-linux-arm64-musl": "2.3.15",
+        "@biomejs/cli-linux-x64": "2.3.15",
+        "@biomejs/cli-linux-x64-musl": "2.3.15",
+        "@biomejs/cli-win32-arm64": "2.3.15",
+        "@biomejs/cli-win32-x64": "2.3.15"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.15.tgz",
+      "integrity": "sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw==",
       "cpu": [
         "arm64"
       ],
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.15.tgz",
+      "integrity": "sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw==",
       "cpu": [
         "x64"
       ],
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.0.tgz",
-      "integrity": "sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.15.tgz",
+      "integrity": "sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg==",
       "cpu": [
         "arm64"
       ],
@@ -1371,9 +1371,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.15.tgz",
+      "integrity": "sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg==",
       "cpu": [
         "arm64"
       ],
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.0.tgz",
-      "integrity": "sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.15.tgz",
+      "integrity": "sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg==",
       "cpu": [
         "x64"
       ],
@@ -1405,9 +1405,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.15.tgz",
+      "integrity": "sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw==",
       "cpu": [
         "x64"
       ],
@@ -1422,9 +1422,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.15.tgz",
+      "integrity": "sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA==",
       "cpu": [
         "arm64"
       ],
@@ -1439,9 +1439,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.15.tgz",
+      "integrity": "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A==",
       "cpu": [
         "x64"
       ],
@@ -1496,448 +1496,6 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -3907,356 +3465,6 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -5126,16 +4334,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5144,20 +4342,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -5243,13 +4427,6 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
-    },
-    "node_modules/@types/omelette": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/omelette/-/omelette-0.4.5.tgz",
-      "integrity": "sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/oracledb": {
       "version": "6.5.2",
@@ -5349,121 +4526,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -5616,16 +4678,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -5950,16 +5002,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -6096,23 +5138,6 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/chai": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.1.tgz",
-      "integrity": "sha512-48af6xm9gQK8rhIcOxWwdGzIervm8BVTin+yRp9HEvU20BtVZ2lBywlIJBzwaDtvo0FvjeL7QdCADoUoqIbV3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6159,16 +5184,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -6186,14 +5201,11 @@
       }
     },
     "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
+      "license": "MIT"
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
@@ -6515,23 +5527,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -6661,16 +5656,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deepmerge": {
@@ -6885,13 +5870,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6919,48 +5897,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6982,16 +5918,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -7072,23 +5998,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -9363,13 +8272,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
-    "node_modules/loupe": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
-      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -9395,16 +8297,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-dir": {
@@ -9586,25 +8478,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -9799,23 +8672,21 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
-      "integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.2.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
     },
     "node_modules/oauth-1.0a": {
@@ -10110,16 +8981,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -10263,18 +9124,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
-        "pathe": "^2.0.3"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10282,35 +9131,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postgres-array": {
@@ -10760,51 +9580,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -10964,13 +9739,6 @@
         "suid": "bin/short-unique-id"
       }
     },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11090,16 +9858,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -11149,20 +9907,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -11256,26 +10000,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/strnum": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
@@ -11360,96 +10084,14 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinyexec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tinypool": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/tmpl": {
@@ -11530,18 +10172,13 @@
       }
     },
     "node_modules/trpc-cli": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/trpc-cli/-/trpc-cli-0.10.2.tgz",
-      "integrity": "sha512-zBkL88AeX0vQLXwEAcX6WUoT4Sopr97nFDFeD1zmW33wHQwBKbszylplNVk6BO/cuhgm/iq8/cG27NokqKA1mw==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/trpc-cli/-/trpc-cli-0.12.4.tgz",
+      "integrity": "sha512-Yo2Ob5J7hUZSWZ2A1M9Kb+0qfSxwmcmYIs3kkQyLd3sn0qU4ryGzNsySfrY3+urqp6FnDnIIdbCSqC9BKxK6Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@trpc/server": "^11.1.1",
-        "@types/omelette": "^0.4.4",
-        "commander": "^14.0.0",
-        "picocolors": "^1.0.1",
-        "zod": "^3.25.3",
-        "zod-to-json-schema": "^3.23.0"
+        "commander": "^14.0.0"
       },
       "bin": {
         "trpc-cli": "dist/bin.js"
@@ -11550,36 +10187,32 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@inquirer/prompts": "*",
-        "omelette": "*"
+        "@orpc/server": "^1.0.0",
+        "@trpc/server": "^10.45.2 || ^11.0.1",
+        "@valibot/to-json-schema": "^1.1.0",
+        "effect": "^3.14.2 || ^4.0.0",
+        "valibot": "^1.1.0",
+        "zod": "^3.24.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
-        "@inquirer/prompts": {
+        "@orpc/server": {
           "optional": true
         },
-        "omelette": {
+        "@trpc/server": {
+          "optional": true
+        },
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/trpc-cli/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/trpc-cli/node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "node_modules/ts-mixer": {
@@ -11634,22 +10267,81 @@
       }
     },
     "node_modules/ultracite": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-5.2.3.tgz",
-      "integrity": "sha512-sX0SQH1cTMGvCJobeszjhq9AwywTb3Uup1BiV/eEu6pQqAxqGEX2HMnAmS6Niw3h5xyB52elfRvSdUGyAYiP8Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-6.5.1.tgz",
+      "integrity": "sha512-PeS2L9L4EDINVVUHW+H/pnmidCetWX2a9/baF+C7Foi3hF3lKLRn5oaBjaP7FGTURcTwfeoZg0ZaYB7ULDdtxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
+        "@trpc/server": "^11.8.0",
         "deepmerge": "^4.3.1",
+        "glob": "^13.0.0",
         "jsonc-parser": "^3.3.1",
-        "nypm": "^0.6.1",
-        "trpc-cli": "^0.10.0",
-        "vitest": "^3.2.4",
-        "zod": "^4.0.5"
+        "nypm": "^0.6.2",
+        "picocolors": "^1.1.1",
+        "trpc-cli": "^0.12.1",
+        "zod": "^4.1.13"
       },
       "bin": {
         "ultracite": "dist/index.js"
+      }
+    },
+    "node_modules/ultracite/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/ultracite/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/ultracite/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ultracite/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/undici-types": {
@@ -11804,228 +10496,6 @@
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
-    "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -12112,23 +10582,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/winston": {
@@ -12297,9 +10750,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
-      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.15",
+    "@biomejs/biome": "2.4.13",
     "husky": "9.1.7",
     "jest": "29.7.0",
     "lint-staged": "16.1.5",
     "nock": "13.5.6",
     "prettier": "3.6.2",
-    "ultracite": "6.5.1"
+    "ultracite": "7.6.2"
   },
   "scripts": {
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.2.0",
+    "@biomejs/biome": "2.3.15",
     "husky": "9.1.7",
     "jest": "29.7.0",
     "lint-staged": "16.1.5",
     "nock": "13.5.6",
     "prettier": "3.6.2",
-    "ultracite": "5.2.3"
+    "ultracite": "6.5.1"
   },
   "scripts": {
     "prepare": "husky",

--- a/packages/commerce-sdk-auth/src/ims-auth.ts
+++ b/packages/commerce-sdk-auth/src/ims-auth.ts
@@ -14,17 +14,17 @@ governing permissions and limitations under the License.
 import { ClientCredentials } from "simple-oauth2";
 
 export interface ImsAuthParams {
-  host?: string;
   clientId: string;
   clientSecret: string;
+  host?: string;
   scopes: string[];
 }
 
 interface ImsTokenResponse {
   access_token: string;
-  token_type: string;
-  expires_in: number;
   expires_at: string;
+  expires_in: number;
+  token_type: string;
 }
 
 /**

--- a/packages/commerce-sdk-auth/src/ims-auth.ts
+++ b/packages/commerce-sdk-auth/src/ims-auth.ts
@@ -13,19 +13,19 @@ governing permissions and limitations under the License.
 // @ts-expect-error - simple-oauth2 is not typed
 import { ClientCredentials } from "simple-oauth2";
 
-export type ImsAuthParams = {
+export interface ImsAuthParams {
   host?: string;
   clientId: string;
   clientSecret: string;
   scopes: string[];
-};
+}
 
-type ImsTokenResponse = {
+interface ImsTokenResponse {
   access_token: string;
   token_type: string;
   expires_in: number;
   expires_at: string;
-};
+}
 
 /**
  * Generate access token to connect with Adobe tools (e.g. IO Events)

--- a/packages/commerce-sdk-auth/src/integration-auth.ts
+++ b/packages/commerce-sdk-auth/src/integration-auth.ts
@@ -2,10 +2,10 @@ import crypto from "node:crypto";
 
 import OAuth1a from "oauth-1.0a";
 
-export type IntegrationAuthParams = {
+export interface IntegrationAuthParams {
   consumerKey: string;
   consumerSecret: string;
-};
+}
 
 export function getOAuthHeader({
   consumerKey,

--- a/test/actions/customer/commerce/consumer/consumer.test.js
+++ b/test/actions/customer/commerce/consumer/consumer.test.js
@@ -309,43 +309,40 @@ describe("Given customer commerce consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns the status code %p and response",
-      async (statusCode, response) => {
-        const type =
-          "com.adobe.commerce.test_app.observer.customer_group_delete_commit_after";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns the status code %p and response", async (statusCode, response) => {
+      const type =
+        "com.adobe.commerce.test_app.observer.customer_group_delete_commit_after";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = {
-          type,
-          EVENT_PREFIX: "test_app",
-          ENABLE_TELEMETRY: "true",
-          data: {
-            value: {
-              customer_group_code: "xxx",
-            },
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
           },
-        };
+        },
+      };
+      const params = {
+        type,
+        EVENT_PREFIX: "test_app",
+        ENABLE_TELEMETRY: "true",
+        data: {
+          value: {
+            customer_group_code: "xxx",
+          },
+        },
+      };
 
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
 });

--- a/test/actions/customer/external/consumer/consumer.test.js
+++ b/test/actions/customer/external/consumer/consumer.test.js
@@ -28,22 +28,23 @@ describe("Given customer external consumer", () => {
     });
   });
   describe("When required params are missing", () => {
-    it.each([{}, { data: {} }, { type: "be-observer.customer_create" }])(
-      "Then for parameter %p returns error message",
-      async (params) => {
-        const INVALID_REQUEST_PARAMS_RESPONSE = {
-          error: {
-            body: {
-              error: expect.any(String),
-            },
-            statusCode: HTTP_BAD_REQUEST,
+    it.each([
+      {},
+      { data: {} },
+      { type: "be-observer.customer_create" },
+    ])("Then for parameter %p returns error message", async (params) => {
+      const INVALID_REQUEST_PARAMS_RESPONSE = {
+        error: {
+          body: {
+            error: expect.any(String),
           },
-        };
-        expect(await consumer.main(params)).toMatchObject(
-          INVALID_REQUEST_PARAMS_RESPONSE,
-        );
-      },
-    );
+          statusCode: HTTP_BAD_REQUEST,
+        },
+      };
+      expect(await consumer.main(params)).toMatchObject(
+        INVALID_REQUEST_PARAMS_RESPONSE,
+      );
+    });
   });
   describe("When customer event type received is not supported", () => {
     test("Then returns error response", async () => {
@@ -100,16 +101,13 @@ describe("Given customer external consumer", () => {
         "customer-backoffice/group-deleted",
         { one: "one", two: "two" },
       ],
-    ])(
-      "Then returns success response for %p action",
-      async (_name, type, action, data) => {
-        const params = { type, data };
-        const invocation = jest.fn();
-        Openwhisk.prototype.invokeAction = invocation;
-        await consumer.main(params);
-        expect(invocation).toHaveBeenCalledWith(action, data);
-      },
-    );
+    ])("Then returns success response for %p action", async (_name, type, action, data) => {
+      const params = { type, data };
+      const invocation = jest.fn();
+      Openwhisk.prototype.invokeAction = invocation;
+      await consumer.main(params);
+      expect(invocation).toHaveBeenCalledWith(action, data);
+    });
   });
   describe("When downstream throw an exception", () => {
     test("Then returns error response", async () => {
@@ -137,33 +135,30 @@ describe("Given customer external consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns error response with the status code %p",
-      async (statusCode, response) => {
-        const type = "be-observer.customer_create";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns error response with the status code %p", async (statusCode, response) => {
+      const type = "be-observer.customer_create";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = { type, data: {} };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
+          },
+        },
+      };
+      const params = { type, data: {} };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
   describe("When downstream returns a success response", () => {
     test("Then returns success response", async () => {

--- a/test/actions/customer/external/deleted/validator.test.js
+++ b/test/actions/customer/external/deleted/validator.test.js
@@ -19,15 +19,12 @@ describe("Given customer external deleted validator", () => {
     });
   });
   describe("When data to validate is valid", () => {
-    it.each([[{ data: { id: 1234 } }]])(
-      "Then for %o,  returns successful response",
-      (params) => {
-        const SUCCESSFUL_RESPONSE = { success: true };
-        expect(validator.validateData(params)).toMatchObject(
-          SUCCESSFUL_RESPONSE,
-        );
-      },
-    );
+    it.each([
+      [{ data: { id: 1234 } }],
+    ])("Then for %o,  returns successful response", (params) => {
+      const SUCCESSFUL_RESPONSE = { success: true };
+      expect(validator.validateData(params)).toMatchObject(SUCCESSFUL_RESPONSE);
+    });
   });
   describe("When data to validate is not valid", () => {
     it.each([

--- a/test/actions/ingestion/webhook/webhook.test.js
+++ b/test/actions/ingestion/webhook/webhook.test.js
@@ -186,16 +186,12 @@ describe("Given external backoffice events ingestion webhook", () => {
         },
       };
 
-      getImsAuthProvider.mockImplementation(() => {
-        return {
-          getAccessToken: () => {
-            throw new Error("fake error");
-          },
-          getHeaders: () => {
-            return {};
-          },
-        };
-      });
+      getImsAuthProvider.mockImplementation(() => ({
+        getAccessToken: () => {
+          throw new Error("fake error");
+        },
+        getHeaders: () => ({}),
+      }));
 
       const response = await action.main(params);
 

--- a/test/actions/oauth1a.test.js
+++ b/test/actions/oauth1a.test.js
@@ -20,8 +20,8 @@ describe("getClient", () => {
     expect(client).toBeDefined();
   });
 
-  it("throw an error when authOptions are not declared", () => {
-    return expect(() => {
+  it("throw an error when authOptions are not declared", () =>
+    expect(() => {
       getClient(
         {
           url: "http://localhost:9000/",
@@ -31,8 +31,7 @@ describe("getClient", () => {
       );
     }).toThrow(
       "Unknown auth type, supported IMS OAuth or Commerce OAuth1. Please review documented auth types",
-    );
-  });
+    ));
 
   it("should add a OAuth header when using Commerce OAuth1a credentials", async () => {
     const client = getClient(
@@ -50,9 +49,7 @@ describe("getClient", () => {
 
     const scope = nock("http://commerce.adobe.io", {
       reqheaders: {
-        Authorization: (value) => {
-          return value.includes("OAuth");
-        },
+        Authorization: (value) => value.includes("OAuth"),
       },
     })
       .matchHeader("accept", "application/json")
@@ -88,9 +85,7 @@ describe("getClient", () => {
 
     const scope = nock("http://commerce.adobe.io", {
       reqheaders: {
-        Authorization: (value) => {
-          return value.includes("Bearer TOKEN");
-        },
+        Authorization: (value) => value.includes("Bearer TOKEN"),
       },
     })
       .matchHeader("accept", "application/json")

--- a/test/actions/order/external/consumer/consumer.test.js
+++ b/test/actions/order/external/consumer/consumer.test.js
@@ -71,16 +71,13 @@ describe("Given order external consumer", () => {
         "order-backoffice/updated",
         { one: "one", two: "two" },
       ],
-    ])(
-      "Then returns success response for %p action",
-      async (_, type, action, data) => {
-        const params = { type, data };
-        const invocation = jest.fn();
-        Openwhisk.prototype.invokeAction = invocation;
-        await consumer.main(params);
-        expect(invocation).toHaveBeenCalledWith(action, data);
-      },
-    );
+    ])("Then returns success response for %p action", async (_, type, action, data) => {
+      const params = { type, data };
+      const invocation = jest.fn();
+      Openwhisk.prototype.invokeAction = invocation;
+      await consumer.main(params);
+      expect(invocation).toHaveBeenCalledWith(action, data);
+    });
   });
   describe("When downstream throw an exception", () => {
     test("Then returns error response", async () => {
@@ -108,33 +105,30 @@ describe("Given order external consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns error response with the status code %p",
-      async (statusCode, response) => {
-        const type = "be-observer.sales_order_status_update";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns error response with the status code %p", async (statusCode, response) => {
+      const type = "be-observer.sales_order_status_update";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = { type, data: {} };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
+          },
+        },
+      };
+      const params = { type, data: {} };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
   describe("When downstream returns a success response", () => {
     test("Then returns success response", async () => {

--- a/test/actions/product/commerce/consumer/consumer.test.js
+++ b/test/actions/product/commerce/consumer/consumer.test.js
@@ -230,43 +230,40 @@ describe("Given product commerce consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns the status code %p and response",
-      async (statusCode, response) => {
-        const params = {
-          EVENT_PREFIX: "test_app",
-          type: "com.adobe.commerce.test_app.observer.catalog_product_save_commit_after",
-          data: {
-            value: {
-              sku: "SKU",
-              name: "PRODUCT",
-              description: "Product description",
-              created_at: "2000-01-01",
-              updated_at: "2000-01-02",
-            },
+    ])("Then returns the status code %p and response", async (statusCode, response) => {
+      const params = {
+        EVENT_PREFIX: "test_app",
+        type: "com.adobe.commerce.test_app.observer.catalog_product_save_commit_after",
+        data: {
+          value: {
+            sku: "SKU",
+            name: "PRODUCT",
+            description: "Product description",
+            created_at: "2000-01-01",
+            updated_at: "2000-01-02",
           },
-        };
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+        },
+      };
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
+          },
+        },
+      };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
 });

--- a/test/actions/product/external/consumer/consumer.test.js
+++ b/test/actions/product/external/consumer/consumer.test.js
@@ -51,22 +51,23 @@ describe("Given product external consumer", () => {
 
   describe("When required params are missing", () => {
     logger.debug("When required params are missing");
-    it.each([{}, { data: {} }, { type: "be-observer.catalog_product_create" }])(
-      "Then for parameter %p returns error message",
-      async (params) => {
-        const INVALID_REQUEST_PARAMS_RESPONSE = {
-          error: {
-            body: {
-              error: expect.any(String),
-            },
-            statusCode: HTTP_BAD_REQUEST,
+    it.each([
+      {},
+      { data: {} },
+      { type: "be-observer.catalog_product_create" },
+    ])("Then for parameter %p returns error message", async (params) => {
+      const INVALID_REQUEST_PARAMS_RESPONSE = {
+        error: {
+          body: {
+            error: expect.any(String),
           },
-        };
-        expect(await consumer.main(params)).toMatchObject(
-          INVALID_REQUEST_PARAMS_RESPONSE,
-        );
-      },
-    );
+          statusCode: HTTP_BAD_REQUEST,
+        },
+      };
+      expect(await consumer.main(params)).toMatchObject(
+        INVALID_REQUEST_PARAMS_RESPONSE,
+      );
+    });
   });
 
   describe("When product event type received is not supported", () => {
@@ -108,17 +109,14 @@ describe("Given product external consumer", () => {
         "product-backoffice/deleted",
         { one: "one", two: "two" },
       ],
-    ])(
-      "Then returns success response for %p action",
-      async (_name, type, action, data) => {
-        logger.debug("When product event received is valid");
-        const params = { type, data };
-        const invocation = jest.fn();
-        Openwhisk.prototype.invokeAction = invocation;
-        await consumer.main(params);
-        expect(invocation).toHaveBeenCalledWith(action, data);
-      },
-    );
+    ])("Then returns success response for %p action", async (_name, type, action, data) => {
+      logger.debug("When product event received is valid");
+      const params = { type, data };
+      const invocation = jest.fn();
+      Openwhisk.prototype.invokeAction = invocation;
+      await consumer.main(params);
+      expect(invocation).toHaveBeenCalledWith(action, data);
+    });
   });
 
   describe("When downstream throw an exception", () => {
@@ -161,44 +159,41 @@ describe("Given product external consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns error response with the status code %p",
-      async (statusCode, response) => {
-        const type = "be-observer.catalog_product_create";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns error response with the status code %p", async (statusCode, response) => {
+      const type = "be-observer.catalog_product_create";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = {
-          type,
-          data: {
-            value: {
-              sku: "SKU",
-              name: "PRODUCT",
-              description: "Product description",
-              created_at: "2000-01-01",
-              updated_at: "2000-01-01",
-            },
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
           },
-        };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const params = {
+        type,
+        data: {
+          value: {
+            sku: "SKU",
+            name: "PRODUCT",
+            description: "Product description",
+            created_at: "2000-01-01",
+            updated_at: "2000-01-01",
+          },
+        },
+      };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
 
   describe("When downstream returns a success response", () => {

--- a/test/actions/stock/commerce/consumer/consumer.test.js
+++ b/test/actions/stock/commerce/consumer/consumer.test.js
@@ -106,37 +106,34 @@ describe("Given stock commerce consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns the status code %p and response",
-      async (statusCode, response) => {
-        const type =
-          "com.adobe.commerce.test_app.observer.cataloginventory_stock_item_save_commit_after";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns the status code %p and response", async (statusCode, response) => {
+      const type =
+        "com.adobe.commerce.test_app.observer.cataloginventory_stock_item_save_commit_after";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = {
-          type,
-          EVENT_PREFIX: "test_app",
-          data: { value: { customer_group_code: "xxx" } },
-        };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
+          },
+        },
+      };
+      const params = {
+        type,
+        EVENT_PREFIX: "test_app",
+        data: { value: { customer_group_code: "xxx" } },
+      };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await action.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
 });

--- a/test/actions/stock/external/consumer/consumer.test.js
+++ b/test/actions/stock/external/consumer/consumer.test.js
@@ -28,22 +28,23 @@ describe("Given stock external consumer", () => {
     });
   });
   describe("When required params are missing", () => {
-    it.each([{}, { data: {} }, { type: "be-observer.catalog_stock_create" }])(
-      "Then for parameter %p returns error message",
-      async (params) => {
-        const INVALID_REQUEST_PARAMS_RESPONSE = {
-          error: {
-            body: {
-              error: expect.any(String),
-            },
-            statusCode: HTTP_BAD_REQUEST,
+    it.each([
+      {},
+      { data: {} },
+      { type: "be-observer.catalog_stock_create" },
+    ])("Then for parameter %p returns error message", async (params) => {
+      const INVALID_REQUEST_PARAMS_RESPONSE = {
+        error: {
+          body: {
+            error: expect.any(String),
           },
-        };
-        expect(await consumer.main(params)).toMatchObject(
-          INVALID_REQUEST_PARAMS_RESPONSE,
-        );
-      },
-    );
+          statusCode: HTTP_BAD_REQUEST,
+        },
+      };
+      expect(await consumer.main(params)).toMatchObject(
+        INVALID_REQUEST_PARAMS_RESPONSE,
+      );
+    });
   });
   describe("When stock event type received is not supported", () => {
     test("Then returns error response", async () => {
@@ -65,16 +66,13 @@ describe("Given stock external consumer", () => {
   describe("When stock event received is valid", () => {
     it.each([
       ["be-observer.catalog_stock_update", "stock-backoffice/updated", "data"],
-    ])(
-      "When type is %p, Then forwards the request to the %p action",
-      async (type, action, data) => {
-        const params = { type, data };
-        const invocation = jest.fn();
-        Openwhisk.prototype.invokeAction = invocation;
-        await consumer.main(params);
-        expect(invocation).toHaveBeenCalledWith(action, data);
-      },
-    );
+    ])("When type is %p, Then forwards the request to the %p action", async (type, action, data) => {
+      const params = { type, data };
+      const invocation = jest.fn();
+      Openwhisk.prototype.invokeAction = invocation;
+      await consumer.main(params);
+      expect(invocation).toHaveBeenCalledWith(action, data);
+    });
   });
   describe("When downstream throw an exception", () => {
     test("Then returns error response", async () => {
@@ -102,33 +100,30 @@ describe("Given stock external consumer", () => {
       [HTTP_BAD_REQUEST, { success: false, error: "Invalid data" }],
       [HTTP_NOT_FOUND, { success: false, error: "Entity not found" }],
       [HTTP_INTERNAL_ERROR, { success: false, error: "Internal error" }],
-    ])(
-      "Then returns error response with the status code %p",
-      async (statusCode, response) => {
-        const type = "be-observer.catalog_stock_update";
-        const ACTION_RESPONSE = {
-          response: {
-            result: {
-              body: response,
-              statusCode,
-            },
-          },
-        };
-        const CONSUMER_RESPONSE = {
-          error: {
+    ])("Then returns error response with the status code %p", async (statusCode, response) => {
+      const type = "be-observer.catalog_stock_update";
+      const ACTION_RESPONSE = {
+        response: {
+          result: {
+            body: response,
             statusCode,
-            body: {
-              error: response.error,
-            },
           },
-        };
-        const params = { type, data: {} };
-        Openwhisk.prototype.invokeAction = jest
-          .fn()
-          .mockResolvedValue(ACTION_RESPONSE);
-        expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
-      },
-    );
+        },
+      };
+      const CONSUMER_RESPONSE = {
+        error: {
+          statusCode,
+          body: {
+            error: response.error,
+          },
+        },
+      };
+      const params = { type, data: {} };
+      Openwhisk.prototype.invokeAction = jest
+        .fn()
+        .mockResolvedValue(ACTION_RESPONSE);
+      expect(await consumer.main(params)).toMatchObject(CONSUMER_RESPONSE);
+    });
   });
   describe("When downstream returns a success response", () => {
     test("Then returns success response", async () => {

--- a/test/utils/naming.test.js
+++ b/test/utils/naming.test.js
@@ -60,14 +60,16 @@ describe("Given naming file", () => {
       providers.map(({ key: providerKey }) => ({ providerKey, entityName })),
     );
 
-    test.each(cases)(
-      "naming.getRegistrationName($providerKey, $entityName) returns strings with 25 or less chars",
-      ({ providerKey, entityName }) => {
-        const MAX_LENGTH = 25;
-        const result = naming.getRegistrationName(providerKey, entityName);
+    test.each(
+      cases,
+    )("naming.getRegistrationName($providerKey, $entityName) returns strings with 25 or less chars", ({
+      providerKey,
+      entityName,
+    }) => {
+      const MAX_LENGTH = 25;
+      const result = naming.getRegistrationName(providerKey, entityName);
 
-        expect(result.length).toBeLessThanOrEqual(MAX_LENGTH);
-      },
-    );
+      expect(result.length).toBeLessThanOrEqual(MAX_LENGTH);
+    });
   });
 });

--- a/utils/naming.js
+++ b/utils/naming.js
@@ -19,7 +19,7 @@ const SEPARATOR = "-";
  * @returns the suffix
  */
 function labelSuffix(runtimeNamespace) {
-  return runtimeNamespace.substring(runtimeNamespace.indexOf(SEPARATOR) + 1);
+  return runtimeNamespace.slice(runtimeNamespace.indexOf(SEPARATOR) + 1);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Upgrade `@biomejs/biome` from `2.2.0` to `2.4.13` and `ultracite` from `5.2.3` to `7.6.2`
- Update `biome.jsonc` extends to `ultracite/biome/core` (new path in ultracite 7.x)
- Fix resulting lint errors: `useConsistentArrowReturn`, `noSubstr`, stale `biome-ignore` suppressions, `useConsistentTypeDefinitions` in `commerce-sdk-auth`
- Disable `noGlobalDirnameFilename` globally — this is a CJS project, `__dirname` is valid

## Test plan

- [x] `npm run code:report` — no errors
- [x] `npm test` — 76/76 suites pass