### PR TITLE
CEXT-6067: use only native fetch

### DIFF
--- a/actions/oauth1a.js
+++ b/actions/oauth1a.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const got = require("got");
 const { getIntegrationAuthProvider } = require("@adobe/aio-commerce-lib-auth");
 const { getAdobeAccessToken } = require("../utils/adobe-auth");
 
@@ -92,16 +91,19 @@ function createClient(options, params, logger) {
       }
 
       const headers = {
+        Accept: "application/json",
         ...customHeaders,
         ...authHeaders,
       };
-      return await got(requestData.url, {
-        http2: true,
+      const response = await fetch(requestData.url, {
         method: requestData.method,
         headers,
         body: requestData.body,
-        responseType: "json",
-      }).json();
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return response.json();
     } catch (error) {
       logger.error(`Error fetching URL ${requestData.url}: ${error}`);
       throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "ansis": "^4.1.0",
         "cloudevents": "^10.0.0",
         "dotenv": "^17.0.0",
-        "got": "^11.8.5",
         "graphql-request": "^7.1.2",
         "node-fetch": "^2.7.0",
         "openwhisk": "^3.21.8",
@@ -3473,18 +3472,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4200,18 +4187,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.150",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.150.tgz",
@@ -4272,18 +4247,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4307,12 +4270,6 @@
       "version": "17.1.15",
       "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.15.tgz",
       "integrity": "sha512-Ehq/YQB0ZqZGObrGngztxtThTiShrG0jlqyUSsNK3cebJSoyYgE/hdZvYt6lH4Wimi28RowDwnr87XseiemqAg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -4340,15 +4297,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/memcached": {
@@ -4414,15 +4362,6 @@
       "license": "MIT",
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4952,33 +4891,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5273,18 +5185,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cloudevents": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-10.0.0.tgz",
@@ -5526,33 +5426,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -5587,15 +5460,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -5729,15 +5593,6 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -6276,21 +6131,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6332,31 +6172,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -6473,12 +6288,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/http-link-header": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
@@ -6499,19 +6308,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -7582,12 +7378,6 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7693,15 +7483,6 @@
       "dependencies": {
         "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -8201,15 +7982,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8329,15 +8101,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minim": {
@@ -8553,18 +8316,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -8606,6 +8357,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8710,15 +8462,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -9172,16 +8915,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -9198,18 +8931,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ramda": {
       "version": "0.30.1",
@@ -9310,12 +9031,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT"
-    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -9347,18 +9062,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -10381,6 +10084,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "husky": "9.1.7",
         "jest": "29.7.0",
         "lint-staged": "16.4.0",
-        "nock": "13.5.6",
         "prettier": "3.8.3",
         "ultracite": "7.6.2"
       },
@@ -7390,13 +7389,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -8191,21 +8183,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
-    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -8872,16 +8849,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/protobufjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "cloudevents": "^10.0.0",
         "dotenv": "^17.0.0",
         "graphql-request": "^7.1.2",
-        "node-fetch": "^2.7.0",
         "openwhisk": "^3.21.8",
         "valibot": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "husky": "9.1.7",
     "jest": "29.7.0",
     "lint-staged": "16.4.0",
-    "nock": "13.5.6",
     "prettier": "3.8.3",
     "ultracite": "7.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cloudevents": "^10.0.0",
     "dotenv": "^17.0.0",
     "graphql-request": "^7.1.2",
-    "node-fetch": "^2.7.0",
     "openwhisk": "^3.21.8",
     "valibot": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "ansis": "^4.1.0",
     "cloudevents": "^10.0.0",
     "dotenv": "^17.0.0",
-    "got": "^11.8.5",
     "graphql-request": "^7.1.2",
     "node-fetch": "^2.7.0",
     "openwhisk": "^3.21.8",

--- a/scripts/lib/metadata.js
+++ b/scripts/lib/metadata.js
@@ -10,8 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fetch = require("node-fetch");
-
 const { makeError } = require("./helpers/errors");
 const providersEventsConfig = require("../onboarding/config/events.json");
 const { getEventName } = require("../../utils/naming");

--- a/scripts/lib/providers.js
+++ b/scripts/lib/providers.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 require("dotenv").config();
 
-const fetch = require("node-fetch");
 const fs = require("node:fs");
 const path = require("node:path");
 const envPath = path.resolve(__dirname, "../../.env");

--- a/scripts/lib/registrations.js
+++ b/scripts/lib/registrations.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fetch = require("node-fetch");
 const { getExistingRegistrations } = require("../../utils/adobe-events-api");
 const { getRegistrationName } = require("../../utils/naming");
 const { getEventName } = require("../../utils/naming");

--- a/test/actions/ingestion/webhook/webhook.test.js
+++ b/test/actions/ingestion/webhook/webhook.test.js
@@ -50,14 +50,15 @@ jest.mock("@adobe/aio-commerce-lib-auth", () => {
 
 const { getImsAuthProvider } = require("@adobe/aio-commerce-lib-auth");
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
+let fetchSpy;
 
 beforeEach(() => {
-  Events.init.mockClear(); // only clears calls stats
+  Events.init.mockClear();
+  fetchSpy = jest.spyOn(global, "fetch");
 });
 
 afterEach(() => {
+  fetchSpy.mockRestore();
   jest.clearAllMocks();
   jest.resetModules();
 });
@@ -120,7 +121,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockResolvedValueOnce(
+      fetchSpy.mockResolvedValueOnce(
         createMockFetchProvidersResponse([
           {
             id: "PROVIDER_ID",
@@ -257,7 +258,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockRejectedValue(new Error("fake error"));
+      fetchSpy.mockRejectedValue(new Error("fake error"));
 
       const response = await action.main(params);
 
@@ -289,7 +290,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockResolvedValueOnce({
+      fetchSpy.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({}),
       });
@@ -324,7 +325,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockResolvedValueOnce(
+      fetchSpy.mockResolvedValueOnce(
         createMockFetchProvidersResponse([
           {
             id: "PROVIDER_ID",
@@ -369,7 +370,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockResolvedValueOnce(
+      fetchSpy.mockResolvedValueOnce(
         createMockFetchProvidersResponse([
           {
             id: "PROVIDER_ID",
@@ -415,7 +416,7 @@ describe("Given external backoffice events ingestion webhook", () => {
       };
 
       mockResolvedAccessToken();
-      fetch.mockResolvedValueOnce(
+      fetchSpy.mockResolvedValueOnce(
         createMockFetchProvidersResponse([
           {
             id: "PROVIDER_ID",

--- a/test/actions/oauth1a.test.js
+++ b/test/actions/oauth1a.test.js
@@ -1,10 +1,17 @@
 const { HTTP_OK } = require("../../actions/constants");
 const { getClient } = require("../../actions/oauth1a");
-const nock = require("nock");
 
 jest.mock("../../utils/adobe-auth", () => ({
   getAdobeAccessToken: jest.fn().mockResolvedValue("TOKEN"),
 }));
+
+const mockJsonResponse = (body, ok = true) =>
+  Promise.resolve({
+    ok,
+    status: ok ? HTTP_OK : 500,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: () => Promise.resolve(body),
+  });
 
 describe("getClient", () => {
   it("should return a client", () => {
@@ -38,6 +45,10 @@ describe("getClient", () => {
     ));
 
   it("should add a OAuth header when using Commerce OAuth1a credentials", async () => {
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() => mockJsonResponse({ success: true }));
+
     const client = getClient(
       {
         url: "http://commerce.adobe.io/",
@@ -51,21 +62,26 @@ describe("getClient", () => {
       console,
     );
 
-    const scope = nock("http://commerce.adobe.io", {
-      reqheaders: {
-        Authorization: (value) => value.includes("OAuth"),
-      },
-    })
-      .matchHeader("accept", "application/json")
-      .get("/V1/foo")
-      .reply(HTTP_OK, { success: true });
-    expect(await client.get("foo", "")).toStrictEqual({
-      success: true,
-    });
-    scope.done();
+    expect(await client.get("foo", "")).toStrictEqual({ success: true });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://commerce.adobe.io/V1/foo",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          Authorization: expect.stringContaining("OAuth"),
+        }),
+      }),
+    );
+
+    fetchSpy.mockRestore();
   });
 
   it("should add a Authorization with Bearer <TOKEN> when receiving a success response from IMS", async () => {
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() => mockJsonResponse({ success: true }));
+
     const client = getClient(
       {
         url: "http://commerce.adobe.io/",
@@ -78,20 +94,18 @@ describe("getClient", () => {
       console,
     );
 
-    const scope = nock("http://commerce.adobe.io", {
-      reqheaders: {
-        Authorization: (value) => value.includes("Bearer TOKEN"),
-      },
-    })
-      .matchHeader("accept", "application/json")
-      .get("/V1/foo")
-      .reply(HTTP_OK, { success: true });
+    expect(await client.get("foo", "")).toStrictEqual({ success: true });
 
-    const result = await client.get("foo", "");
-    expect(result).toStrictEqual({
-      success: true,
-    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://commerce.adobe.io/V1/foo",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          Authorization: "Bearer TOKEN",
+        }),
+      }),
+    );
 
-    scope.done();
+    fetchSpy.mockRestore();
   });
 });

--- a/test/scripts/lib/onboarding.metadata.test.js
+++ b/test/scripts/lib/onboarding.metadata.test.js
@@ -10,15 +10,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
+let fetchSpy;
 const action = require("../../../scripts/lib/metadata.js");
 const ACCESS_TOKEN = "token";
 const ENVIRONMENT = {
   EVENT_PREFIX: "test-project",
 };
 
+beforeEach(() => {
+  fetchSpy = jest.spyOn(global, "fetch");
+});
+
 afterEach(() => {
+  fetchSpy.mockRestore();
   jest.clearAllMocks();
   jest.resetModules();
 });
@@ -61,7 +65,7 @@ describe("Given on-boarding metadata file", () => {
             },
           }),
       };
-      fetch.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
+      fetchSpy.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
 
       const clientRegistrations = require("../../data/onboarding/metadata/create_commerce_and_backoffice_providers_metadata.json");
       const response = await action.main(
@@ -106,7 +110,7 @@ describe("Given on-boarding metadata file", () => {
           }),
       };
 
-      fetch.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
+      fetchSpy.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
 
       const clientRegistrations = require("../../data/onboarding/metadata/create_only_commerce_providers_metadata.json");
       const response = await action.main(
@@ -146,7 +150,7 @@ describe("Given on-boarding metadata file", () => {
             },
           }),
       };
-      fetch.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
+      fetchSpy.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
 
       const clientRegistrations = require("../../data/onboarding/metadata/create_only_backoffice_providers_metadata.json");
       const response = await action.main(
@@ -170,7 +174,7 @@ describe("Given on-boarding metadata file", () => {
   describe("When metadata process API call fails", () => {
     test("Then returns error response", async () => {
       const fakeError = new Error("fake");
-      fetch.mockRejectedValue(fakeError);
+      fetchSpy.mockRejectedValue(fakeError);
       const clientRegistrations = require("../../data/onboarding/metadata/create_commerce_and_backoffice_providers_metadata.json");
       const response = await action.main(
         clientRegistrations,
@@ -210,7 +214,7 @@ describe("Given on-boarding metadata file", () => {
             message: "Please provide valid data",
           }),
       };
-      fetch.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
+      fetchSpy.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
 
       const clientRegistrations = require("../../data/onboarding/metadata/create_commerce_and_backoffice_providers_metadata.json");
       const environment = {

--- a/test/scripts/lib/onboarding.providers.test.js
+++ b/test/scripts/lib/onboarding.providers.test.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-jest.mock("node-fetch");
 jest.mock("node:path", () => {
   const originalPath = jest.requireActual("node:path");
   return {
@@ -27,7 +26,7 @@ jest.mock("node:path", () => {
   };
 });
 
-const fetch = require("node-fetch");
+let fetchSpy;
 const fs = require("node:fs");
 const path = require("node:path");
 const action = require("../../../scripts/lib/providers.js");
@@ -42,11 +41,12 @@ const TEST_ENV_PATH = path.resolve(
 
 beforeEach(() => {
   jest.resetModules();
-  // Reset path.resolve mock calls
   path.resolve.mockClear();
+  fetchSpy = jest.spyOn(global, "fetch");
 });
 
 afterEach(() => {
+  fetchSpy.mockRestore();
   jest.clearAllMocks();
 });
 
@@ -377,7 +377,7 @@ describe("Given On-boarding providers file", () => {
           }),
       };
 
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateCommerceProviderResponse)
         .mockResolvedValueOnce(mockFetchCreateBackofficeProviderResponse);
@@ -628,7 +628,7 @@ describe("Given On-boarding providers file", () => {
             },
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateCommerceProviderResponse);
 
@@ -872,7 +872,7 @@ describe("Given On-boarding providers file", () => {
             },
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateBackofficeProviderResponse);
 
@@ -1118,7 +1118,7 @@ describe("Given On-boarding providers file", () => {
             },
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateBackofficeProviderResponse);
 
@@ -1151,7 +1151,7 @@ describe("Given On-boarding providers file", () => {
   describe("When create provider process call to API fails", () => {
     test("Then returns error response", async () => {
       const fakeError = new Error("fake");
-      fetch.mockRejectedValue(fakeError);
+      fetchSpy.mockRejectedValue(fakeError);
       const clientRegistrations = require("../../data/onboarding/providers/create_commerce_and_backoffice_providers.json");
       const response = await action.main(clientRegistrations, ACCESS_TOKEN);
       expect(response).toEqual({
@@ -1321,7 +1321,7 @@ describe("Given On-boarding providers file", () => {
             message: "Please provide valid data",
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateCommerceProviderResponse);
 
@@ -1378,7 +1378,7 @@ describe("Given On-boarding providers file", () => {
           }),
       };
 
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchGetExistingProvidersResponse)
         .mockResolvedValueOnce(mockFetchCreateCommerceProviderResponse);
 

--- a/test/scripts/lib/onboarding.registrations.test.js
+++ b/test/scripts/lib/onboarding.registrations.test.js
@@ -10,11 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-jest.mock("node-fetch");
-const fetch = require("node-fetch");
+let fetchSpy;
 const action = require("../../../scripts/lib/registrations.js");
 
+beforeEach(() => {
+  fetchSpy = jest.spyOn(global, "fetch");
+});
+
 afterEach(() => {
+  fetchSpy.mockRestore();
   jest.clearAllMocks();
   jest.resetModules();
 });
@@ -241,7 +245,7 @@ describe("Given on-boarding registrations file", () => {
             enabled: true,
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchExistingRegistrationResponse)
         .mockResolvedValueOnce(
           mockFetchCreateProductCommerceRegistrationResponse,
@@ -441,7 +445,7 @@ describe("Given on-boarding registrations file", () => {
             enabled: true,
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchExistingRegistrationResponse)
         .mockResolvedValueOnce(
           mockFetchCreateProductCommerceRegistrationResponse,
@@ -632,7 +636,7 @@ describe("Given on-boarding registrations file", () => {
             enabled: true,
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchExistingRegistrationResponse)
         .mockResolvedValueOnce(
           mockFetchCreateProductBackofficeRegistrationResponse,
@@ -823,7 +827,7 @@ describe("Given on-boarding registrations file", () => {
             enabled: true,
           }),
       };
-      fetch
+      fetchSpy
         .mockResolvedValueOnce(mockFetchExistingRegistrationResponse)
         .mockResolvedValueOnce(
           mockFetchCreateProductBackofficeRegistrationResponse,
@@ -859,7 +863,7 @@ describe("Given on-boarding registrations file", () => {
   describe("When create registration process call to API fails", () => {
     test("Then returns error response", async () => {
       const fakeError = new Error("fake");
-      fetch.mockRejectedValue(fakeError);
+      fetchSpy.mockRejectedValue(fakeError);
 
       const clientRegistrations = require("../../data/onboarding/registrations/create_commerce_and_backoffice_registrations.json");
       const response = await action.main(
@@ -897,7 +901,7 @@ describe("Given on-boarding registrations file", () => {
           }),
       };
 
-      fetch.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
+      fetchSpy.mockResolvedValue(mockFetchCreateProviderMetadataResponse);
 
       const clientRegistrations = require("../../data/onboarding/registrations/create_commerce_and_backoffice_registrations.json");
       const environment = {

--- a/utils/adobe-events-api.js
+++ b/utils/adobe-events-api.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fetch = require("node-fetch");
 const { getProviderName } = require("./naming");
 
 /**


### PR DESCRIPTION
Supersedes #110, #111, #113, #114.

## Why

This PR eliminates two third-party HTTP dependencies — `got` and `node-fetch` — replacing both with the native `fetch` global available on Node ≥22 (already the minimum engine for this project).

### `got` (v11)

`got` v11 is the last CJS-compatible release, published December 2022 with no updates since. `got` v12+ is pure ESM and cannot be `require()`d in Jest's CJS environment — the same class of breakage already seen with `uuid` and `camelcase`. Pinning an abandoned version means security vulnerabilities will never be patched upstream.

All pending Renovate bumps for `got` (#110, #111, #113, #114) become unnecessary once the dependency is removed entirely.

### `node-fetch` (v2)

`node-fetch` v2 is similarly frozen: the last v2 patch was in 2022 and the maintainers have declared it in maintenance-only mode. It is HTTP/1.1 only and carries known vulnerabilities that will not be backported. v3+ is pure ESM, making an upgrade a breaking change in this CJS codebase.

## Benefits of native fetch

| | `got` v11 | `node-fetch` v2 | Native `fetch` (Node 22) |
|---|---|---|---|
| Actively maintained | No | No | Yes (Node.js core) |
| Security patches | None since 2022 | None since 2022 | Shipped with every Node release |
| Zero dependencies | — | — | Yes |
| HTTP/2 support | No | No | Yes (via undici) |
| CJS compatible | Yes | Yes | Yes (global — no import) |
| Bundle size impact | ~200 kB | ~30 kB | 0 kB |

Removing both packages eliminates two attack-surface dependencies from the supply chain entirely. Any future CVE in `got` or `node-fetch` will no longer affect this project.
