### PR TITLE
CEXT-6067: sync node version across .nvmrc and runtime actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,16 @@
   "commitMessagePrefix": "RENOVATE: ",
   "labels": ["dependencies"],
   "postUpdateOptions": ["npmDedupe"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.config\\.yaml$"],
+      "matchStrings": ["runtime: nodejs:(?<currentValue>\\d+)"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",
@@ -47,6 +57,12 @@
         "@adobe/aio-commerce-lib-*",
         "@adobe/aio-commerce-sdk*"
       ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "groupName": "node version",
+      "matchPackageNames": ["node"],
       "matchUpdateTypes": ["major"],
       "automerge": false
     }


### PR DESCRIPTION
## Problem

When Renovate bumps Node.js (e.g. PR #117 `.nvmrc` 22 → 24), the `runtime: nodejs:22` entries in every `*.config.yaml` action file are left behind — they are invisible to Renovate today because it doesn't know about that field.

This repo has 37+ occurrences of `runtime: nodejs:22` across 11 action config files that must be updated manually alongside `.nvmrc`.

## Solution

**Custom regex manager** — teaches Renovate to track `runtime: nodejs:<major>` in any `*.config.yaml` file using the same `node-version` datasource as `.nvmrc`.

**Node version package rule** — groups all `node` major updates (`.nvmrc`, `package.json` engines, and all YAML runtime entries) into a single Renovate PR so they always stay in sync.

```json
"customManagers": [
  {
    "customType": "regex",
    "fileMatch": ["\\.config\\.yaml$"],
    "matchStrings": ["runtime: nodejs:(?<currentValue>\\d+)"],
    "depNameTemplate": "node",
    "datasourceTemplate": "node-version",
    "versioningTemplate": "node"
  }
]
```

```json
{
  "groupName": "node version",
  "matchPackageNames": ["node"],
  "matchUpdateTypes": ["major"],
  "automerge": false
}
```

## Result

Next time Renovate proposes a Node.js major bump, a single PR will update:
- `.nvmrc`: `22.x.x` → `24.x.x`
- `package.json` engines: `>=22.0.0` → `>=24.0.0`
- All `*.config.yaml` files: `runtime: nodejs:22` → `runtime: nodejs:24`

## Related

- PR #117 — current Node 24 bump that triggered this (only updates `.nvmrc`)
