### PR TITLE
RENOVATE: use optional-quote pattern in node runtime matchStrings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/\\.config\\.yaml$/"],
-      "matchStrings": ["runtime: nodejs:(?<currentValue>\\d+)"],
+      "matchStrings": ["runtime: ['\"]?nodejs:(?<currentValue>\\d+)['\"]?"],
       "depNameTemplate": "node",
       "datasourceTemplate": "node-version",
       "versioningTemplate": "node"


### PR DESCRIPTION
## Summary

Updates the custom regex manager's `matchStrings` to use an optional-quote character class, making the pattern consistent with `commerce-checkout-starter-kit` where `ext.config.yaml` uses single-quoted runtime values.

**Before:** `runtime: nodejs:(?<currentValue>\\d+)` — unquoted only  
**After:** `runtime: ['\"]?nodejs:(?<currentValue>\\d+)['\"]?` — unquoted, single-quoted, or double-quoted

The integration starter kit's current YAML files all use unquoted syntax so this is a no-op functionally, but keeps both repos in sync and future-proofs against quote style changes.
